### PR TITLE
feat: 단체 정보 수정 페이지 퍼블리싱

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react": "^18.3.1",
     "react-cookie": "^7.2.2",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.53.2",
     "styled-components": "^6.1.13"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.53.2
+        version: 7.53.2(react@18.3.1)
       styled-components:
         specifier: ^6.1.13
         version: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1352,6 +1355,12 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-hook-form@7.53.2:
+    resolution: {integrity: sha512-YVel6fW5sOeedd1524pltpHX+jgU2u3DSDtXEaBORNdqiNrsX/nUI/iGXONegttg0mJVnfrIkiV0cmTU6Oo2xw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -2724,6 +2733,10 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-hook-form@7.53.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-is@16.13.1: {}
 

--- a/src/routes/organizations/$organizationId/-edit.style.ts
+++ b/src/routes/organizations/$organizationId/-edit.style.ts
@@ -1,0 +1,94 @@
+import styled from "styled-components";
+
+export const StyledContainer = styled.form`
+  width: 100%;
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 20px;
+`;
+
+export const StyledTitle = styled.h1`
+  font-size: 24px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 32px;
+  text-align: center;
+`;
+
+export const StyledFieldGroup = styled.div`
+  margin-bottom: 24px;
+`;
+
+export const StyledLabel = styled.div`
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+  margin-bottom: 8px;
+`;
+
+export const StyledDetailLabel = styled.div`
+  font-size: 9px;
+  font-weight: 400;
+  color: #4f4f4f;
+  margin-bottom: 8px;
+`;
+
+export const StyledLabelRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const StyledInput = styled.input`
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #e1e1e8;
+  border-radius: 8px;
+  font-size: 14px;
+
+  &::placeholder {
+    font-size: 12px;
+    color: #b3b3b3;
+  }
+`;
+
+export const StyledImageUpload = styled.div`
+  width: 100%;
+  height: 100px;
+  border: 1px solid #e1e1e8;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin-bottom: 16px;
+
+  &:hover {
+    background: #e1e1e8;
+  }
+`;
+
+export const StyledButton = styled.button`
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #e1e1e8;
+  border-radius: 8px;
+  text-align: center;
+  cursor: pointer;
+
+  &:hover {
+    background: #e1e1e8;
+  }
+`;
+
+export const StyledImageInput = styled.input`
+  display: none;
+`;
+
+export const StyledImage = styled.img`
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: cover;
+`;
+
+export const StyledAdd = styled.span``;

--- a/src/routes/organizations/$organizationId/edit.lazy.tsx
+++ b/src/routes/organizations/$organizationId/edit.lazy.tsx
@@ -30,7 +30,7 @@ interface GroupFormData {
 }
 
 function RouteComponent() {
-  const imageInputRef = useRef<HTMLInputElement>(null);
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
   const { register, handleSubmit, watch, setValue } = useForm<GroupFormData>({
     defaultValues: {
       name: "",
@@ -97,6 +97,10 @@ function RouteComponent() {
             <StyledAdd>+</StyledAdd>
           )}
           <StyledImageInput
+            ref={(e) => {
+              imageInputRef.current = e;
+              register("image").ref(e);
+            }}
             id="imageInput"
             type="file"
             accept="image/*"

--- a/src/routes/organizations/$organizationId/edit.lazy.tsx
+++ b/src/routes/organizations/$organizationId/edit.lazy.tsx
@@ -1,0 +1,110 @@
+import { createLazyFileRoute } from "@tanstack/react-router";
+import { useRef } from "react";
+import { useForm } from "react-hook-form";
+import {
+  StyledAdd,
+  StyledButton,
+  StyledContainer,
+  StyledDetailLabel,
+  StyledFieldGroup,
+  StyledImage,
+  StyledImageInput,
+  StyledImageUpload,
+  StyledInput,
+  StyledLabel,
+  StyledLabelRow,
+  StyledTitle,
+} from "./-edit.style";
+
+export const Route = createLazyFileRoute("/organizations/$organizationId/edit")(
+  {
+    component: RouteComponent,
+  }
+);
+
+interface GroupFormData {
+  name: string;
+  secretNumber: string;
+  description: string;
+  image: File | null;
+}
+
+function RouteComponent() {
+  const imageInputRef = useRef<HTMLInputElement>(null);
+  const { register, handleSubmit, watch, setValue } = useForm<GroupFormData>({
+    defaultValues: {
+      name: "",
+      secretNumber: "",
+      description: "",
+      image: null,
+    },
+  });
+
+  const imageFile = watch("image");
+
+  const onSubmit = (data: GroupFormData) => {
+    console.log(data);
+  };
+
+  const handleImageUploadClick = () => {
+    if (imageInputRef.current) {
+      imageInputRef.current.click();
+    }
+  };
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] || null;
+    setValue("image", file);
+  };
+
+  return (
+    <StyledContainer onSubmit={handleSubmit(onSubmit)}>
+      <StyledTitle>단체 정보 수정</StyledTitle>
+      <StyledFieldGroup>
+        <StyledLabel>단체명</StyledLabel>
+        <StyledInput
+          {...register("name", { required: true })}
+          placeholder="단체명을 입력하세요"
+        />
+      </StyledFieldGroup>
+      <StyledFieldGroup>
+        <StyledLabel>단체 비밀번호</StyledLabel>
+        <StyledInput
+          type="password"
+          autoComplete="off"
+          {...register("secretNumber", { required: true })}
+          placeholder="비밀번호를 입력하세요"
+        />
+      </StyledFieldGroup>
+      <StyledFieldGroup>
+        <StyledLabelRow>
+          <StyledLabel>단체 설명</StyledLabel>
+          <StyledDetailLabel>
+            * 구성원들이 공간을 예약할 때 사용하는 비밀번호 입니다
+          </StyledDetailLabel>
+        </StyledLabelRow>
+        <StyledInput
+          {...register("description", { required: true })}
+          placeholder="단체에 대한 설명을 입력하세요"
+        />
+      </StyledFieldGroup>
+      <StyledFieldGroup>
+        <StyledLabel>공간사진</StyledLabel>
+        <StyledImageUpload onClick={handleImageUploadClick}>
+          {imageFile ? (
+            <StyledImage src={URL.createObjectURL(imageFile)} alt="단체 사진" />
+          ) : (
+            <StyledAdd>+</StyledAdd>
+          )}
+          <StyledImageInput
+            id="imageInput"
+            type="file"
+            accept="image/*"
+            onChange={handleImageChange}
+          />
+        </StyledImageUpload>
+      </StyledFieldGroup>
+      <StyledButton type="submit">수정</StyledButton>
+    </StyledContainer>
+  );
+}

--- a/src/routes/organizations/$organizationId/index.lazy.tsx
+++ b/src/routes/organizations/$organizationId/index.lazy.tsx
@@ -1,4 +1,4 @@
-import { createLazyFileRoute } from "@tanstack/react-router";
+import { createLazyFileRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { OrganizationInfoCard } from "../../-components/OrganizationInfoCard/OrganizationInfoCard";
 import { SpaceCard } from "../../-components/SpaceCard/SpaceCard";
@@ -17,9 +17,14 @@ export const Route = createLazyFileRoute("/organizations/$organizationId/")({
 function RouteComponent() {
   const [organization] = useState<Organization>(mockOrganization);
   const [spaces] = useState<Space[]>(mockSpaces);
+  const { organizationId } = Route.useParams();
+  const navigate = useNavigate();
 
   const handleEditOrganization = () => {
-    // 단체 정보 수정 페이지로 이동
+    navigate({
+      to: "/organizations/$organizationId/edit",
+      params: { organizationId },
+    });
   };
 
   const handleEditSpace = (spaceId: number) => {


### PR DESCRIPTION
https://github.com/user-attachments/assets/74d3fb40-bff2-4faa-87b4-31d4088748cd

단체 정보 수정 페이지를 퍼블리싱했습니다.
`/organizations/{$organizationId}/edit` 페이지 경로입니당

나중에 모달로 빼거나 푸터를 수정하거나 헤더푸터 없이 하거나... 해야될 듯

## 변경 사항

- rhf 설치
- 그 외 딱히 없음
