### PR TITLE
feat: 2-2 검색 결과 페이지 퍼블리싱

### DIFF
--- a/src/routes/-components/Footer/Footer.tsx
+++ b/src/routes/-components/Footer/Footer.tsx
@@ -1,18 +1,7 @@
-import { Link, useRouter } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { StyledContainer, StyledFooter } from "./Footer.style.ts";
 
 function Footer() {
-  const router = useRouter();
-
-  const isModalRoute =
-    router.matchRoute({
-      to: "/organizations/$organizationId/edit",
-    }) ||
-    router.matchRoute({
-      to: "/organizations/$organizationId/spaceEdit/$spaceId",
-    });
-
-  if (isModalRoute) return null;
   return (
     <StyledFooter>
       <StyledContainer>

--- a/src/routes/-components/GroupCard/GroupCard.style.ts
+++ b/src/routes/-components/GroupCard/GroupCard.style.ts
@@ -1,0 +1,86 @@
+export interface Organization {
+  id: number;
+  name: string;
+  description: string;
+  logoImageUrl: string;
+  tags: string[];
+}
+
+export interface GroupCardProps {
+  group: Organization;
+  onClick: (space: string, groupId: number) => void;
+}
+
+import styled from "styled-components";
+export const CardWrapper = styled.div`
+  display: flex;
+  background: white;
+  box-shadow: 0 0 0 0.5px #858585;
+  border-radius: 20px;
+  overflow: hidden;
+  cursor: pointer;
+  padding: 40px;
+  align-items: center;
+  gap: 40px;
+`;
+
+export const GroupImage = styled.div`
+  width: 216px;
+  height: 184px;
+  overflow: hidden;
+  flex-shrink: 0;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`;
+
+export const GroupContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+  color: #000;
+`;
+
+export const GroupName = styled.div`
+  font-size: 24px;
+  font-weight: 600;
+`;
+
+export const GroupDescription = styled.div`
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 1.5;
+  margin: 10px 0;
+  max-width: 430px;
+`;
+
+export const StyledTags = styled.div`
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+`;
+
+export const StyledTag = styled.span`
+  padding: 10px 20px;
+  background: #ffffff;
+  border-radius: 45px;
+  border: 0.5px solid #858585;
+  font-size: 18px;
+  font-weight: 500;
+  color: #3a3a3a;
+`;
+
+export const StyledViewSpaceButton = styled.button`
+  padding: 10px 20px;
+  background: #1781ee;
+  color: white;
+  border: none;
+  border-radius: 12px;
+  font-size: 20px;
+  font-weight: 500;
+  cursor: pointer;
+`;

--- a/src/routes/-components/GroupCard/GroupCard.tsx
+++ b/src/routes/-components/GroupCard/GroupCard.tsx
@@ -1,0 +1,37 @@
+import {
+  CardWrapper,
+  GroupCardProps,
+  GroupContent,
+  GroupDescription,
+  GroupImage,
+  GroupName,
+  StyledTag,
+  StyledTags,
+  StyledViewSpaceButton,
+} from "./GroupCard.style";
+
+export const GroupCard = ({ group, onClick }: GroupCardProps) => {
+  const handleSpaceView = (space: string) => {
+    onClick(space, group.id);
+  };
+
+  return (
+    <CardWrapper>
+      <GroupImage>
+        <img src={group.logoImageUrl} alt={group.name} />
+      </GroupImage>
+      <GroupContent>
+        <GroupName>{group.name}</GroupName>
+        <GroupDescription>{group.description}</GroupDescription>
+        <StyledTags>
+          {group.tags.map((tag) => (
+            <StyledTag key={tag}>#{tag}</StyledTag>
+          ))}
+        </StyledTags>
+      </GroupContent>
+      <StyledViewSpaceButton onClick={() => handleSpaceView(group.name)}>
+        공간보기
+      </StyledViewSpaceButton>
+    </CardWrapper>
+  );
+};

--- a/src/routes/SearchResult/$query/-index.style.ts
+++ b/src/routes/SearchResult/$query/-index.style.ts
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+
+export const SearchContainer = styled.div`
+  width: 100%;
+  max-width: 1220px;
+  margin: 0 auto;
+  padding: 60px;
+`;
+
+export const SearchHeader = styled.div`
+  padding: 10px;
+  font-size: 28px;
+  font-weight: 700;
+  margin-bottom: 16px;
+`;
+
+export const StyledHr = styled.div`
+  width: 100%;
+  border-top: 0.5px solid #858585;
+  margin-bottom: 40px;
+`;
+
+export const SearchResultsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: 20px 0;
+`;

--- a/src/routes/SearchResult/$query/index.lazy.tsx
+++ b/src/routes/SearchResult/$query/index.lazy.tsx
@@ -1,0 +1,94 @@
+import {
+  createLazyFileRoute,
+  useParams,
+  useRouter,
+} from "@tanstack/react-router";
+import { GroupCard } from "../../-components/GroupCard/GroupCard";
+import { Organization } from "../../-components/GroupCard/GroupCard.style";
+import logo from "../../../assets/mockLogo.svg";
+import logo2 from "../../../assets/test.jpg";
+import {
+  SearchContainer,
+  SearchHeader,
+  SearchResultsGrid,
+  StyledHr,
+} from "./-index.style";
+
+export const Route = createLazyFileRoute("/SearchResult/$query/")({
+  component: SearchResults,
+});
+
+function SearchResults() {
+  const { query } = useParams({
+    from: "/SearchResult/$query/",
+  });
+  const router = useRouter();
+
+  const groups: Organization[] = [
+    {
+      id: 1,
+      name: "동아리 A",
+      description:
+        "유어슈 서로를 존중하고 커뮤니케이션 하는 동아리입니다. 성장하는 문화를 통해 같이 있는 것만으로 즐겁게 배울 수 있는 동아리입니다.",
+      logoImageUrl: logo,
+      tags: ["공간 1", "공간 2", "공간 3", "공간 4"],
+    },
+    {
+      id: 2,
+      name: "동아리 A",
+      description: "동아리 A에 대한 설명입니다.",
+      logoImageUrl: logo,
+      tags: ["공간 1", "공간 2", "공간 3", "공간 4"],
+    },
+    {
+      id: 3,
+      name: "동아리 A",
+      description: "동아리 A에 대한 설명입니다.",
+      logoImageUrl: logo2,
+      tags: ["공간 1", "공간 2", "공간 3", "공간 4"],
+    },
+    {
+      id: 4,
+      name: "동아리 A",
+      description: "동아리 A에 대한 설명입니다.",
+      logoImageUrl: logo2,
+      tags: ["공간 1", "공간 2", "공간 3", "공간 4"],
+    },
+    {
+      id: 5,
+      name: "동아리 A",
+      description: "동아리 A에 대한 설명입니다.",
+      logoImageUrl: logo2,
+      tags: ["공간 1", "공간 2", "공간 3", "공간 4"],
+    },
+  ];
+
+  // const filteredGroups = groups.filter((group) =>
+  //   group.name.includes(query || "")
+  // );
+
+  // const handleSearch = (space: string) => {
+  //   console.log(`Selected space: ${space}`);
+  // };
+
+  const handleGroupClick = (space: string, groupId: number) => {
+    handleSpaceSelect(space, groupId);
+  };
+
+  const handleSpaceSelect = (space: string, id: number) => {
+    console.log(`Selected space: ${space}`);
+    router.navigate({ to: `/organizations/${id}` });
+  };
+
+  return (
+    <SearchContainer>
+      <SearchHeader>단체 정보 / 검색 결과: {query}</SearchHeader>
+      <StyledHr />
+      <SearchResultsGrid>
+        {groups.map((group) => (
+          <GroupCard key={group.id} group={group} onClick={handleGroupClick} />
+        ))}
+      </SearchResultsGrid>
+    </SearchContainer>
+  );
+}


### PR DESCRIPTION

https://github.com/user-attachments/assets/e2924d36-4cdb-46ef-9c44-34cbddd886e2

검색 결과 페이지를 퍼블리싱 했습니다.

- query 스트링으로 받을 예정
- 위에 검색이랑 연동은 추후에... 헤더가 걍 다르던데 ㅣㅣㅣ;;; 아님 제롬이 해주지않ㅇㄹ까...?
- 공간보기 하면 받아온 id로 organizationid로 만들어서 페이지 이동시킴
- 검색 결과 : n 이거 나중에 삭제 할 예정