### PR TITLE
feat: 1-3, 1-4 api 연결

### DIFF
--- a/src/api/getOneOrganization.ts
+++ b/src/api/getOneOrganization.ts
@@ -1,0 +1,9 @@
+import { customAxios } from ".";
+import { Organization } from "../types/organization.type";
+
+export const getOneOrganization = async (organizationId: number) => {
+  const { data } = await customAxios.get<Organization>(
+    `/organizations/${organizationId}`
+  );
+  return data;
+};

--- a/src/api/patchOrganization.ts
+++ b/src/api/patchOrganization.ts
@@ -1,0 +1,46 @@
+import { customAxios } from ".";
+
+interface PatchOrganizationRequest {
+  name: string;
+  description: string;
+  reservationPassword: string | null;
+  hashtags: string[];
+  imageFile?: File | null;
+}
+
+export const patchOrganization = async (
+  organizationId: number,
+  data: PatchOrganizationRequest
+) => {
+  const formData = new FormData();
+
+  const requestData = {
+    name: data.name,
+    description: data.description,
+    reservationPassword: data.reservationPassword,
+    hashtags: data.hashtags,
+  };
+
+  formData.append(
+    "request",
+    new Blob([JSON.stringify(requestData)], {
+      type: "application/json",
+    })
+  );
+
+  if (data.imageFile) {
+    formData.append("image", data.imageFile);
+  }
+
+  const response = await customAxios.patch(
+    `/organizations/${organizationId}`,
+    formData,
+    {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    }
+  );
+
+  return response.data;
+};

--- a/src/api/patchSpace.ts
+++ b/src/api/patchSpace.ts
@@ -1,0 +1,46 @@
+import { customAxios } from ".";
+
+export interface SpaceFormData {
+  name: string;
+  location: string;
+  openingTime: string;
+  closingTime: string;
+  capacity: number;
+  image?: File | null;
+}
+
+export type UpdateSpaceParams = {
+  name: string;
+  location: string;
+  openingTime: string;
+  closingTime: string;
+  capacity: number;
+  image?: File | null;
+};
+
+export const patchSpace = async (spaceId: number, data: UpdateSpaceParams) => {
+  const formData = new FormData();
+
+  const requestData = {
+    name: data.name,
+    location: data.location,
+    openingTime: data.openingTime,
+    closingTime: data.closingTime,
+    capacity: data.capacity,
+  };
+
+  const request = new Blob([JSON.stringify(requestData)], {
+    type: "application/json",
+  });
+
+  formData.append("request", request);
+  if (data.image) formData.append("image", data.image);
+
+  const response = await customAxios.patch(`/spaces/${spaceId}`, formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
+  return response.data;
+};

--- a/src/api/postLogin.ts
+++ b/src/api/postLogin.ts
@@ -5,7 +5,7 @@ export interface PostLoginParams {
   password: string;
 }
 
-interface PostLoginResponse {
+export interface PostLoginResponse {
   id: number;
   name: string;
   accessToken: string;

--- a/src/hooks/usePostLogin.ts
+++ b/src/hooks/usePostLogin.ts
@@ -1,19 +1,24 @@
 import { useMutation } from "@tanstack/react-query";
-import { postLogin, PostLoginParams } from "../api/postLogin.ts";
+import {
+  postLogin,
+  PostLoginParams,
+  PostLoginResponse,
+} from "../api/postLogin.ts";
 import { api } from "../service/TokenService.ts";
 
 interface UsePostLoginParams {
-  then?: () => void;
+  then?: (data: PostLoginResponse) => void;
 }
 
 export const usePostLogin = ({ then }: UsePostLoginParams) => {
   return useMutation({
     mutationFn: (params: PostLoginParams) => postLogin(params),
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
       api.setAccessToken(data.accessToken);
       api.setRefreshToken(data.refreshToken);
       api.setUserId(data.id);
-      then?.();
+      api.setPassword(variables.password);
+      then?.(data);
     },
   });
 };

--- a/src/hooks/usePostLogin.ts
+++ b/src/hooks/usePostLogin.ts
@@ -1,24 +1,19 @@
 import { useMutation } from "@tanstack/react-query";
-import {
-  postLogin,
-  PostLoginParams,
-  PostLoginResponse,
-} from "../api/postLogin.ts";
+import { postLogin, PostLoginParams } from "../api/postLogin.ts";
 import { api } from "../service/TokenService.ts";
 
 interface UsePostLoginParams {
-  then?: (data: PostLoginResponse) => void;
+  then?: () => void;
 }
 
 export const usePostLogin = ({ then }: UsePostLoginParams) => {
   return useMutation({
     mutationFn: (params: PostLoginParams) => postLogin(params),
-    onSuccess: (data, variables) => {
+    onSuccess: (data) => {
       api.setAccessToken(data.accessToken);
       api.setRefreshToken(data.refreshToken);
       api.setUserId(data.id);
-      api.setPassword(variables.password);
-      then?.(data);
+      then?.();
     },
   });
 };

--- a/src/hooks/usePostOrganization.ts
+++ b/src/hooks/usePostOrganization.ts
@@ -1,8 +1,19 @@
-import {useMutation} from "@tanstack/react-query";
-import {postOrganization, PostOrganizationParams} from "../api/postOrganization.ts";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  postOrganization,
+  PostOrganizationParams,
+} from "../api/postOrganization.ts";
+import { api } from "../service/TokenService";
 
 export const usePostOrganization = () => {
-    return useMutation({
-        mutationFn: (params: PostOrganizationParams) => postOrganization(params)
-    })
-}
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: (params: PostOrganizationParams) => postOrganization(params),
+    onSuccess: (_, variables) => {
+      api.setOrganizationPassword(variables.reservationPassword);
+      navigate({ to: "/" });
+    },
+  });
+};

--- a/src/routes/-components/ReservationStatusBar/ReservationStatusBar.tsx
+++ b/src/routes/-components/ReservationStatusBar/ReservationStatusBar.tsx
@@ -141,7 +141,7 @@ export const ReservationStatusBar = ({
 
       setSelectedSlots(newSelectedSlots);
       onTimeSelect(newSelectedSlots);
-      //   setSelectionStart(null);
+      setSelectionStart(null);
     }
   };
 

--- a/src/routes/-components/SignIn/SignIn.tsx
+++ b/src/routes/-components/SignIn/SignIn.tsx
@@ -1,90 +1,99 @@
+import { useForm } from "react-hook-form";
 import Modal from "react-modal";
+import { PostLoginParams } from "../../../api/postLogin.ts";
+import { usePostLogin } from "../../../hooks/usePostLogin.ts";
 import {
-    StyledButton,
-    StyledButtonWrapper,
-    StyledContent, StyledErrorMessage,
-    StyledFieldLabel,
-    StyledFieldWrapper,
-    StyledH2,
-    StyledInput, StyledLink, StyledLogo
+  StyledButton,
+  StyledButtonWrapper,
+  StyledContent,
+  StyledErrorMessage,
+  StyledFieldLabel,
+  StyledFieldWrapper,
+  StyledH2,
+  StyledInput,
+  StyledLink,
+  StyledLogo,
 } from "./SignIn.style.ts";
-import {useForm} from "react-hook-form";
-import {usePostLogin} from "../../../hooks/usePostLogin.ts";
-import {PostLoginParams} from "../../../api/postLogin.ts";
 
 const customStyles = {
-    content: {
-        top: '50%',
-        left: '50%',
-        right: 'auto',
-        bottom: 'auto',
-        marginRight: '-50%',
-        transform: 'translate(-50%, -50%)',
-        padding: '50px'
-    },
+  content: {
+    top: "50%",
+    left: "50%",
+    right: "auto",
+    bottom: "auto",
+    marginRight: "-50%",
+    transform: "translate(-50%, -50%)",
+    padding: "50px",
+  },
 };
 
 interface SignInProps {
-    open: boolean;
-    closeModal: () => void;
+  open: boolean;
+  closeModal: () => void;
 }
 
 type SignInFormFields = PostLoginParams;
 
-const SignIn = ({open, closeModal}: SignInProps) => {
-    const {register, handleSubmit, formState} = useForm<SignInFormFields>();
-    const postLoginMutation = usePostLogin({
-        then: closeModal
-    });
-    const onSubmit = handleSubmit((data) => {
-        postLoginMutation.mutate(data);
-    })
+const SignIn = ({ open, closeModal }: SignInProps) => {
+  const { register, handleSubmit, formState } = useForm<SignInFormFields>();
+  const postLoginMutation = usePostLogin({
+    then: () => {
+      closeModal();
+    },
+  });
 
-    return (
-        <Modal
-            isOpen={open}
-            onRequestClose={closeModal}
-            style={customStyles}
-            contentLabel="Example Modal"
-        >
-            <StyledContent>
-                <StyledLogo>OpenSSUpot</StyledLogo>
-                <StyledH2>로그인</StyledH2>
+  const onSubmit = handleSubmit((data) => {
+    postLoginMutation.mutate(data);
+  });
 
-                <form onSubmit={onSubmit}>
-                    <StyledFieldWrapper>
-                        <StyledFieldLabel htmlFor="email">이메일</StyledFieldLabel>
-                        <StyledInput 
-                            id="email" 
-                            {...register("email", {required: true})} 
-                            type="email"
-                            placeholder="이메일을 입력하세요"
-                        />
-                    </StyledFieldWrapper>
-                    <StyledFieldWrapper>
-                        <StyledFieldLabel htmlFor="password">비밀번호</StyledFieldLabel>
-                        <StyledInput 
-                            id="password" 
-                            {...register("password", {required: true})} 
-                            type="password"
-                            placeholder="비밀번호를 입력하세요"
-                        />
-                    </StyledFieldWrapper>
-                    <StyledErrorMessage>{(formState.errors.email || formState.errors.password || postLoginMutation.isError) && "이메일과 비밀번호를 확인해주세요."}</StyledErrorMessage>
-                    <StyledButtonWrapper>
-                        <StyledLink to={'/signup'}>
-                            <StyledButton type="button" onClick={closeModal} $type="normal">
-                                회원가입
-                            </StyledButton>
-                        </StyledLink>
-                        <StyledButton $type="primary">
-                            로그인
-                        </StyledButton>
-                    </StyledButtonWrapper>
-                </form>
-            </StyledContent>
-        </Modal>
-    );
-}
+  return (
+    <Modal
+      isOpen={open}
+      onRequestClose={closeModal}
+      style={customStyles}
+      contentLabel="Example Modal"
+    >
+      <StyledContent>
+        <StyledLogo>OpenSSUpot</StyledLogo>
+        <StyledH2>로그인</StyledH2>
+
+        <form onSubmit={onSubmit}>
+          <StyledFieldWrapper>
+            <StyledFieldLabel htmlFor="email">이메일</StyledFieldLabel>
+            <StyledInput
+              id="email"
+              {...register("email", { required: true })}
+              type="email"
+              placeholder="이메일을 입력하세요"
+            />
+          </StyledFieldWrapper>
+          <StyledFieldWrapper>
+            <StyledFieldLabel htmlFor="password">비밀번호</StyledFieldLabel>
+            <StyledInput
+              id="password"
+              {...register("password", { required: true })}
+              type="password"
+              placeholder="비밀번호를 입력하세요"
+            />
+          </StyledFieldWrapper>
+          <StyledErrorMessage>
+            {(formState.errors.email ||
+              formState.errors.password ||
+              postLoginMutation.isError) &&
+              "이메일과 비밀번호를 확인해주세요."}
+          </StyledErrorMessage>
+          <StyledButtonWrapper>
+            <StyledLink to={"/signup"}>
+              <StyledButton type="button" onClick={closeModal} $type="normal">
+                회원가입
+              </StyledButton>
+            </StyledLink>
+            <StyledButton $type="primary">로그인</StyledButton>
+          </StyledButtonWrapper>
+        </form>
+      </StyledContent>
+    </Modal>
+  );
+};
 
 export default SignIn;

--- a/src/routes/-components/SignIn/SignIn.tsx
+++ b/src/routes/-components/SignIn/SignIn.tsx
@@ -37,11 +37,8 @@ type SignInFormFields = PostLoginParams;
 const SignIn = ({ open, closeModal }: SignInProps) => {
   const { register, handleSubmit, formState } = useForm<SignInFormFields>();
   const postLoginMutation = usePostLogin({
-    then: () => {
-      closeModal();
-    },
+    then: closeModal,
   });
-
   const onSubmit = handleSubmit((data) => {
     postLoginMutation.mutate(data);
   });

--- a/src/routes/organizations/$organizationId/edit/-index.style.ts
+++ b/src/routes/organizations/$organizationId/edit/-index.style.ts
@@ -29,7 +29,6 @@ export const StyledDetailLabel = styled.div`
   font-size: 12px;
   font-weight: 400;
   color: #4f4f4f;
-  margin-bottom: 8px;
   margin-left: 4px;
 `;
 

--- a/src/routes/organizations/$organizationId/edit/index.lazy.tsx
+++ b/src/routes/organizations/$organizationId/edit/index.lazy.tsx
@@ -65,7 +65,11 @@ function RouteComponent() {
         imageFile: data.image,
       });
     },
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
+      const currentPassword = api.getPassword();
+      if (variables.secretNumber !== currentPassword) {
+        api.setPassword(variables.secretNumber);
+      }
       queryClient.invalidateQueries({
         queryKey: ["organization", organizationId],
       });

--- a/src/routes/organizations/$organizationId/open/index.lazy.tsx
+++ b/src/routes/organizations/$organizationId/open/index.lazy.tsx
@@ -38,8 +38,8 @@ function RouteComponent() {
     defaultValues: {
       name: "",
       location: "",
-      openTime: "",
-      closeTime: "",
+      openingTime: "",
+      closingTime: "",
       capacity: "",
       image: null,
     },
@@ -65,8 +65,8 @@ function RouteComponent() {
     const spaceParams: SpaceParams = {
       name: data.name,
       location: data.location,
-      openingTime: data.openTime,
-      closingTime: data.closeTime,
+      openingTime: data.openingTime,
+      closingTime: data.closingTime,
       capacity: Number(data.capacity),
       image: data.image,
     };
@@ -112,13 +112,13 @@ function RouteComponent() {
             <StyledTimeContainer>
               <StyledTimeInput
                 type="time"
-                {...register("openTime", { required: true })}
+                {...register("openingTime", { required: true })}
                 placeholder="오픈 시간을 선택하세요"
               />
               <span>~</span>
               <StyledTimeInput
                 type="time"
-                {...register("closeTime", { required: true })}
+                {...register("closingTime", { required: true })}
                 placeholder="종료 시간을 선택하세요"
               />
             </StyledTimeContainer>

--- a/src/service/TokenService.ts
+++ b/src/service/TokenService.ts
@@ -14,11 +14,11 @@ class TokenService {
     this.cookie.set("userId", id, { path: "/" });
   }
 
-  setPassword(password: string) {
+  setOrganizationPassword(password: string) {
     this.cookie.set("password", password, { path: "/" });
   }
 
-  getPassword() {
+  getOrganizationPassword() {
     return this.cookie.get("password");
   }
 

--- a/src/service/TokenService.ts
+++ b/src/service/TokenService.ts
@@ -14,6 +14,14 @@ class TokenService {
     this.cookie.set("userId", id, { path: "/" });
   }
 
+  setPassword(password: string) {
+    this.cookie.set("password", password, { path: "/" });
+  }
+
+  getPassword() {
+    return this.cookie.get("password");
+  }
+
   getUserId() {
     return this.cookie.get("userId");
   }
@@ -29,6 +37,7 @@ class TokenService {
     this.cookie.remove("accessToken", { path: "/" });
     this.cookie.remove("refreshToken", { path: "/" });
     this.cookie.remove("userId", { path: "/" });
+    this.cookie.remove("password", { path: "/" });
   }
 
   get headers() {

--- a/src/types/space.type.ts
+++ b/src/types/space.type.ts
@@ -1,8 +1,8 @@
 export interface SpaceFormData {
   name: string;
   location: string;
-  openTime: string;
-  closeTime: string;
+  openingTime: string;
+  closingTime: string;
   capacity: number | string;
   image: File | null;
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/dbf4578a-78e1-4c77-9ed5-33082882390b


단체 정보 수정, 공간 정보 수정 api 연결을 했습니다.

- 비밀번호를 tokenservice에서 저장하도록 get/set 추가함
- 로그인할때 올바른 비밀번호 저장하도록 로그인 페이지 코드 조금 수정함 -> 코드 충돌 너어무 걱정돼서 제롬 리뷰어 지정하고 가여
- 근데 막상 비밀번호 받아오니까 쓸모가 없어졌는데... 비밀번호 부분 디자인이 수정되어야 할 것 같아요
=> 원래는 비밀번호가 서버에 암호화되어 저장되어서 프론트로 값을 전달할 수 없기 때문에 프론트에서 저장, 수정할 때 쓰는 거였는데 현재 디자인대로라면 뭐 되는게 없음. 그래서 
1. 이전 비밀번호가 맞은 후 그 다음에 비밀번호 혹은 내용을 수정하게 하던가 
2. 뭐 그런걸로 바꿔야 할 것 같습니디ㅏ.

엔초가 비밀번호가 바뀌지 않았을 경우 null로 보내달라 했는데 저렇게 검증을 하지 않는 이상 그냥 보내도 상관이 없을 것 같구.... (실제로도 안바뀌었는데 계속 그냥 보내고 있음) 디자인이나 추가 기능 안생긴다면 아예 빼버리는게 나을 것 같아요 근데 null로 안보내고 계속 보내도 되나여? 
cc. @kwonyj1022 