### PR TITLE
style: 단체 정보 페이지의 컨테이너가 Viewport의 남은 height를 모두 차지하도록 수정

### DIFF
--- a/src/routes/organizations/$organizationId/-index.style.ts
+++ b/src/routes/organizations/$organizationId/-index.style.ts
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 export const StyledContainer = styled.div`
   width: 100%;
+  height: calc(100vh - 164px);
   max-width: 1220px;
   margin: 0 auto;
   padding: 60px 0;


### PR DESCRIPTION
## 변경 사항
단체 정보 페이지에서 컨테이너가 Viewport의 남은 height를 모두 차지하도록 수정하였습니다.

## 변경 전
![image](https://github.com/user-attachments/assets/652de693-f992-4d2a-8a4a-e1a484e27c35)

## 변경 후
![image](https://github.com/user-attachments/assets/026913f9-3513-498d-a155-5189c7026852)
