### PR TITLE
feat: 헤더 간소화, 로고 네비게이션 비활성화 및 예약 시간 제한 해제

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,12 +1,12 @@
 import { Link, useMatchRoute, useNavigate } from '@tanstack/react-router';
 import { FormEvent, useState } from 'react';
 import SearchIcon from '../../assets/search.svg?react';
+import LogoBlue from '../../assets/spacer_logo_blue.svg';
+import LogoWhite from '../../assets/spacer_logo_white.svg';
 import { useLoginState } from '../../hooks/useLoginState.ts';
 import { api } from '../../service/TokenService.ts';
 import LoginAlert from '../LoginAlert/LoginAlert.tsx';
 import SignIn from '../SignIn/SignIn.tsx';
-import LogoBlue from '../../assets/spacer_logo_blue.svg';
-import LogoWhite from '../../assets/spacer_logo_white.svg';
 
 import {
   IconContainer,
@@ -42,7 +42,8 @@ function Header() {
 
   return (
     <StyledHeader $primary={!isHome}>
-      <Link to="/">
+      {/* <Link to="/"> */}
+      <Link>
         <img width={100} src={isHome ? LogoBlue : LogoWhite} />
       </Link>
       <StyledNav>

--- a/src/components/ReservationCalendar/ReservationCalendar.tsx
+++ b/src/components/ReservationCalendar/ReservationCalendar.tsx
@@ -60,7 +60,7 @@ export const ReservationCalendar = ({ selectedDate, onDateSelect }: ReservationC
   };
 
   const handleDateClick = (date: Date) => {
-    onDateSelect(date);
+    onDateSelect(dayjs(date).startOf('day').toDate());
   };
 
   const renderCalendarCells = () => {

--- a/src/components/ReservationStatusBar/ReservationStatusBar.tsx
+++ b/src/components/ReservationStatusBar/ReservationStatusBar.tsx
@@ -55,6 +55,9 @@ export const ReservationStatusBar = ({
     minute: parseInt(closingTime.split(':')[1]),
   };
 
+  const startHour = openTime.hour;
+  const endHour = closeTime.hour;
+
   const generateTimeSlots = (startHour: number, endHour: number, reservations: Reservation[]) => {
     const slots: TimeSlot[] = [];
 
@@ -94,7 +97,7 @@ export const ReservationStatusBar = ({
     return slots;
   };
 
-  const timeSlots = generateTimeSlots(6, 21, reservations);
+  const timeSlots = generateTimeSlots(startHour, endHour, reservations);
 
   const handleSelect = (hour: number, minute: number) => {
     const slot = timeSlots.find((slot) => slot.hour === hour && slot.minute === minute);

--- a/src/routes/Reservation/$spaceId/state/index.lazy.tsx
+++ b/src/routes/Reservation/$spaceId/state/index.lazy.tsx
@@ -1,11 +1,17 @@
+import { ReservationCalendar } from '@/components/ReservationCalendar/ReservationCalendar.tsx';
+import { ReservationStateCard } from '@/components/ReservationStateCard/ReservationStateCard';
 import { useQuery } from '@tanstack/react-query';
 import { createLazyFileRoute } from '@tanstack/react-router';
 import dayjs from 'dayjs';
 import { useState } from 'react';
-import { ReservationStateCard } from '@/components/ReservationStateCard/ReservationStateCard';
 import { getReservationsTime } from '../../../../api/getReservationInfoTime';
-import { StyledContainer, StyledDivider, StyledGrid, StyledNoResults, StyledTitle } from './-index.style';
-import { ReservationCalendar } from '@/components/ReservationCalendar/ReservationCalendar.tsx';
+import {
+  StyledContainer,
+  StyledDivider,
+  StyledGrid,
+  StyledNoResults,
+  StyledTitle,
+} from './-index.style';
 
 export const Route = createLazyFileRoute('/Reservation/$spaceId/state/')({
   component: RouteComponent,
@@ -13,7 +19,6 @@ export const Route = createLazyFileRoute('/Reservation/$spaceId/state/')({
 
 function RouteComponent() {
   const { spaceId } = Route.useParams();
-
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
 
   const currentDate = dayjs(selectedDate).format('YYYY-MM-DDTHH:mm:00');
@@ -24,19 +29,20 @@ function RouteComponent() {
     enabled: !!spaceId,
   });
 
+  const selectedDateStr = dayjs(selectedDate).format('YYYY-MM-DD');
+  const filteredReservations = reservations.filter(
+    (reservation) => dayjs(reservation.startDateTime).format('YYYY-MM-DD') === selectedDateStr,
+  );
+
   return (
     <StyledContainer>
       <StyledTitle>예약 현황 조회</StyledTitle>
       <ReservationCalendar selectedDate={selectedDate} onDateSelect={setSelectedDate} />
       <StyledDivider />
       <StyledGrid>
-        {reservations.length > 0 ? (
-          reservations.map((reservation) => (
-            <ReservationStateCard
-              key={reservation.id}
-              spaceId={Number(spaceId)}
-              {...reservation}
-            />
+        {filteredReservations.length > 0 ? (
+          filteredReservations.map((reservation) => (
+            <ReservationStateCard key={reservation.id} spaceId={Number(spaceId)} {...reservation} />
           ))
         ) : (
           <StyledNoResults>예약된 내역이 없습니다.</StyledNoResults>


### PR DESCRIPTION
#36 

[pm 요청](https://yourssu.slack.com/archives/C08JBGHU1FX/p1744365004816459)에 따른 수정사항입니다.

**1. 기존 하드코딩 되어있던 공간 예약 시간을 원래 받아오고 있었던 데이터 openTime.hour, closeTime.hour로 변경했습니다.**

<img width="938" alt="스크린샷 2025-04-13 오후 5 52 33" src="https://github.com/user-attachments/assets/713b3a53-4cb2-42aa-ab5d-5a6c1dd8341e" />
<img width="438" alt="스크린샷 2025-04-13 오후 5 57 08" src="https://github.com/user-attachments/assets/a952a1a7-87b2-4b1e-82ae-513f6e509246" />

<img width="1317" alt="스크린샷 2025-04-13 오후 5 52 38" src="https://github.com/user-attachments/assets/ff6a9926-5f74-4287-9498-2568d451e924" />

이 부분!

**2. 헤더에서 로고 눌렀을 때 메인 페이지로 이동하지 않도록 Link 안에 to를 제거했습니다. 나중에 다시 쓰일 날이 오길 바라며 주석처리**

**3. 2-3, 2-4, 2-5 페이지의 헤더 부분 로고만 남기고 안보이게 만들었습니다.**

https://github.com/user-attachments/assets/7a536807-9ce4-47dd-951c-7c5e3e088ce4

정규식 패턴 사용해서 경로 인식하게 했고 특정 경로에만 다른 헤더 요소들 안보이게 했습니당

<img width="937" alt="스크린샷 2025-04-13 오후 6 14 33" src="https://github.com/user-attachments/assets/9a175be8-72fd-4c5a-8a09-e533a17c1476" />

정규식은 지피티가 . . .

**4. 예약 현황 조회에서 캘린더에서 선택한 날짜에 해당하는 예약만 밑에 나오도록 수정했습니다**
원래 명세가 현재 시간을 서버로 보내면 해당하는 날짜 기준 근처 예약 데이터를 프론트로 보내주는 형태였는데 
임시로 프론트에서 파싱해서 캘린더에서 선택한 날짜 - 받아온 예약 데이터 같은 날짜면 밑에 보여지게 했습니다 
-> 이 부분이 디자인이 바뀌면서 명세도 바뀐거라 응답 데이터를 수정해야 해서 나중에 엔초한테 데이터 선택한 날짜만 보내줄수 있냐고 물어봐서 수정할게요!! 우선 순위가 급하지 않아보여서 . . . 스카우터가 시급함 지금...