### PR TITLE
fix: 시간 고정 문제 해결

### DIFF
--- a/src/routes/Reservation/$spaceId/index.lazy.tsx
+++ b/src/routes/Reservation/$spaceId/index.lazy.tsx
@@ -1,13 +1,13 @@
 import { createLazyFileRoute, useNavigate } from '@tanstack/react-router';
 
+import { ReservationCalendar } from '@/components/ReservationCalendar/ReservationCalendar';
+import { ReservationInfoCard } from '@/components/ReservationInfoCard/ReservationInfoCard';
+import { ReservationStatusBar } from '@/components/ReservationStatusBar/ReservationStatusBar';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import dayjs from 'dayjs';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { ReservationCalendar } from '@/components/ReservationCalendar/ReservationCalendar';
-import { ReservationInfoCard } from '@/components/ReservationInfoCard/ReservationInfoCard';
-import { ReservationStatusBar } from '@/components/ReservationStatusBar/ReservationStatusBar';
 import { getOneSpace, getOneSpaceOrga } from '../../../api/getOneSpace';
 import { getReservationInfo } from '../../../api/getReservationInfo';
 import { postSpaceReservation, SpaceReservationRequest } from '../../../api/postSpaceReservation';
@@ -161,12 +161,15 @@ function RouteComponent() {
       const sortedSlots = [...slots].sort(
         (a, b) => a.hour * 60 + a.minute - (b.hour * 60 + b.minute),
       );
-
       const lastSlot = sortedSlots[sortedSlots.length - 1];
+
       let endHour = lastSlot.hour;
       let endMinute = lastSlot.minute + 30;
 
-      if (endMinute === 60) {
+      if (endHour === 23 && endMinute === 60) {
+        endHour = 23;
+        endMinute = 59;
+      } else if (endMinute === 60) {
         endHour += 1;
         endMinute = 0;
       }

--- a/src/routes/Reservation/$spaceId/index.lazy.tsx
+++ b/src/routes/Reservation/$spaceId/index.lazy.tsx
@@ -127,9 +127,18 @@ function RouteComponent() {
     end: { hour: number; minute: number };
   }) => {
     const formatHour = (time: { hour: number; minute: number }) => {
+      if (time.hour === 23 && time.minute === 59) {
+        return '23:59';
+      }
+
       if (time.minute === 60) {
         return `${time.hour + 1}:00`;
       }
+
+      if (time.minute !== 0 && time.minute !== 30) {
+        return `${time.hour}:${time.minute < 10 ? '0' + time.minute : time.minute}`;
+      }
+
       return `${time.hour}:${time.minute === 30 ? '30' : '00'}`;
     };
 

--- a/src/routes/Reservation/$spaceId/state/index.lazy.tsx
+++ b/src/routes/Reservation/$spaceId/state/index.lazy.tsx
@@ -1,10 +1,10 @@
+import { getReservationInfo } from '@/api/getReservationInfo';
 import { ReservationCalendar } from '@/components/ReservationCalendar/ReservationCalendar.tsx';
 import { ReservationStateCard } from '@/components/ReservationStateCard/ReservationStateCard';
 import { useQuery } from '@tanstack/react-query';
 import { createLazyFileRoute } from '@tanstack/react-router';
 import dayjs from 'dayjs';
 import { useState } from 'react';
-import { getReservationsTime } from '../../../../api/getReservationInfoTime';
 import {
   StyledContainer,
   StyledDivider,
@@ -21,11 +21,11 @@ function RouteComponent() {
   const { spaceId } = Route.useParams();
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
 
-  const currentDate = dayjs(selectedDate).format('YYYY-MM-DDTHH:mm:00');
+  const formattedDate = dayjs(selectedDate).format('YYYY-MM-DD');
 
   const { data: reservations = [] } = useQuery({
-    queryKey: ['reservations', spaceId, currentDate],
-    queryFn: () => getReservationsTime(Number(spaceId), currentDate),
+    queryKey: ['reservations', spaceId, formattedDate],
+    queryFn: () => getReservationInfo(Number(spaceId), formattedDate),
     enabled: !!spaceId,
   });
 

--- a/src/routes/organizations/$organizationId/open/-index.style.ts
+++ b/src/routes/organizations/$organizationId/open/-index.style.ts
@@ -195,3 +195,18 @@ export const StyledLabelRow = styled.div`
   align-items: center;
   gap: 8px;
 `;
+
+export const StyledCheckboxWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+  gap: 8px;
+`;
+
+export const StyledCheckbox = styled.input`
+  margin-right: 4px;
+`;
+
+export const StyledCheckboxLabel = styled.label`
+  font-size: 14px;
+`;

--- a/src/routes/organizations/$organizationId/open/index.lazy.tsx
+++ b/src/routes/organizations/$organizationId/open/index.lazy.tsx
@@ -123,8 +123,6 @@ function RouteComponent() {
             <StyledTimeContainer>
               <StyledTimeInput
                 type="time"
-                min="06:00"
-                max="21:00"
                 step="1800"
                 {...register('openingTime', { required: true })}
                 placeholder="오픈 시간을 선택하세요"
@@ -133,8 +131,6 @@ function RouteComponent() {
               <StyledTimeInput
                 type="time"
                 step="1800"
-                min="06:00"
-                max="21:00"
                 {...register('closingTime', { required: true })}
                 placeholder="종료 시간을 선택하세요"
               />

--- a/src/routes/organizations/$organizationId/spaceEdit/$spaceId/-index.style.ts
+++ b/src/routes/organizations/$organizationId/spaceEdit/$spaceId/-index.style.ts
@@ -154,3 +154,18 @@ export const StyledImageNameInput = styled.input`
     color: #858585;
   }
 `;
+
+export const StyledCheckboxWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+  gap: 8px;
+`;
+
+export const StyledCheckbox = styled.input`
+  margin-right: 4px;
+`;
+
+export const StyledCheckboxLabel = styled.label`
+  font-size: 14px;
+`;

--- a/src/routes/organizations/$organizationId/spaceEdit/$spaceId/index.lazy.tsx
+++ b/src/routes/organizations/$organizationId/spaceEdit/$spaceId/index.lazy.tsx
@@ -154,8 +154,6 @@ function RouteComponent() {
             <StyledTimeInput
               type="time"
               step="1800"
-              min="06:00"
-              max="21:00"
               {...register('openingTime', { required: true })}
               placeholder="오픈 시간을 선택하세요"
             />
@@ -163,8 +161,6 @@ function RouteComponent() {
             <StyledTimeInput
               type="time"
               step="1800"
-              min="06:00"
-              max="21:00"
               {...register('closingTime', { required: true })}
               placeholder="종료 시간을 선택하세요"
             />

--- a/src/routes/organizations/$organizationId/spaceEdit/$spaceId/index.lazy.tsx
+++ b/src/routes/organizations/$organizationId/spaceEdit/$spaceId/index.lazy.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createLazyFileRoute, useNavigate } from '@tanstack/react-router';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import Modal from 'react-modal';
 import { getOneSpace } from '../../../../../api/getOneSpace';
@@ -10,6 +10,9 @@ import { modalStyles } from '../../../../../styles/editModal';
 import {
   StyledButton,
   StyledButtonWrapper,
+  StyledCheckbox,
+  StyledCheckboxLabel,
+  StyledCheckboxWrapper,
   StyledContainer,
   StyledDetailLabel,
   StyledFieldGroup,
@@ -35,6 +38,7 @@ function RouteComponent() {
   const { organizationId, spaceId } = Route.useParams();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const [is24Hours, setIs24Hours] = useState(false);
 
   const { data: space } = useQuery({
     queryKey: ['space', spaceId],
@@ -74,18 +78,34 @@ function RouteComponent() {
     if (space) {
       setValue('name', space.name);
       setValue('location', space.location);
+
+      const is24HoursOperation =
+        space.openingTime.slice(0, 5) === '00:00' && space.closingTime.slice(0, 5) === '23:59';
+      setIs24Hours(is24HoursOperation);
+
       setValue('openingTime', space.openingTime.slice(0, 5));
       setValue('closingTime', space.closingTime.slice(0, 5));
       setValue('capacity', space.capacity);
     }
   }, [space, setValue]);
 
+  const handle24HoursToggle = () => {
+    setIs24Hours(!is24Hours);
+    if (!is24Hours) {
+      setValue('openingTime', '00:00');
+      setValue('closingTime', '23:59');
+    } else {
+      setValue('openingTime', '');
+      setValue('closingTime', '');
+    }
+  };
+
   const onSubmit = (data: SpaceFormData) => {
     const updatedData = {
       name: data.name,
       location: data.location,
-      openingTime: data.openingTime,
-      closingTime: data.closingTime,
+      openingTime: is24Hours ? '00:00' : data.openingTime,
+      closingTime: is24Hours ? '23:59' : data.closingTime,
       capacity: Number(data.capacity),
       ...(data.image && { image: data.image }),
     };
@@ -148,23 +168,37 @@ function RouteComponent() {
         <StyledFieldGroup>
           <StyledLabelRow>
             <StyledLabel>공간 사용 가능 시간</StyledLabel>
-            <StyledDetailLabel>예약 가능한 시간은 6-21시로 제한됩니다</StyledDetailLabel>
+            <StyledCheckboxWrapper>
+              <StyledCheckbox
+                type="checkbox"
+                id="is24Hours"
+                checked={is24Hours}
+                onChange={handle24HoursToggle}
+              />
+              <StyledCheckboxLabel htmlFor="is24Hours">24시간 운영</StyledCheckboxLabel>
+            </StyledCheckboxWrapper>
           </StyledLabelRow>
-          <StyledTimeContainer>
-            <StyledTimeInput
-              type="time"
-              step="1800"
-              {...register('openingTime', { required: true })}
-              placeholder="오픈 시간을 선택하세요"
-            />
-            <span>~</span>
-            <StyledTimeInput
-              type="time"
-              step="1800"
-              {...register('closingTime', { required: true })}
-              placeholder="종료 시간을 선택하세요"
-            />
-          </StyledTimeContainer>
+          {!is24Hours ? (
+            <StyledTimeContainer>
+              <StyledTimeInput
+                type="time"
+                step="1800"
+                {...register('openingTime', { required: !is24Hours })}
+                placeholder="오픈 시간을 선택하세요"
+                disabled={is24Hours}
+              />
+              <span>~</span>
+              <StyledTimeInput
+                type="time"
+                step="1800"
+                {...register('closingTime', { required: !is24Hours })}
+                placeholder="종료 시간을 선택하세요"
+                disabled={is24Hours}
+              />
+            </StyledTimeContainer>
+          ) : (
+            <StyledDetailLabel>24시간 운영됩니다 (00:00 ~ 23:59)</StyledDetailLabel>
+          )}
         </StyledFieldGroup>
 
         <StyledFieldGroup>


### PR DESCRIPTION
## 🔍 문제 설명

Resolves #38 

https://github.com/user-attachments/assets/a47805ac-4818-45cc-8b6c-9abad6e8af05


<img width="480" alt="스크린샷 2025-04-27 오후 5 19 14" src="https://github.com/user-attachments/assets/949178b3-b37b-4428-9c0c-d6b8716532cb" />

1. 공간 생성/예약 시스템에서 시간 제한을 해제했습니다 -> 해제한 줄 알았는데 input에 min/max 안지워둠 ㅎ
2. 24시간 운영 시 00:00~23:59로만 설정 가능하도록 수정했습니다
3. 공간 생성 폼에 24시간 운영 체크박스를 추가했습니다

<img width="536" alt="스크린샷 2025-04-27 오후 5 23 40" src="https://github.com/user-attachments/assets/faf353bb-dd59-41a8-88ab-5a74cf3833b7" />

4. 예약 조회 페이지에서 API를 수정하여 날짜별 조회가 정상적으로 작동하도록 했습니다 
-> 디자인이 바뀌면서 API 명세도 "최근 시간 기준 조회"에서 "선택한 날짜의 예약 조회"로 변경되어 관련 로직을 수정했습니다

🛠️ 변경 사항

- handleTimeSelect 함수에서 마지막 슬롯(23:30)의 종료 시간을 00:00 대신 23:59로 처리
- formatTime 함수에서 23:59 시간을 UI에서는 24:00으로 표시하도록 수정
- onSubmit 함수에서 종료 시간이 23:59인 특수 케이스 별도 처리
- 공간 생성 폼에서 24시간 운영 시 종료 시간을 00:00 대신 23:59로 설정
- 예약 조회 API를 getReservationsTime에서 getReservationInfo로 변경하고 날짜 형식 수정
