### PR TITLE
feat: 헤더의 교내회의실 찾기 링크 비활성화

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -73,7 +73,11 @@ function Header() {
               공간오픈/관리
             </StyledLink>
             <LoginAlert open={loginAlertOpen} closeModal={() => setLoginAlertOpen(false)} />
-            <StyledLink $primary={!isHome} to="/meetingRooms">
+            <StyledLink
+              $primary={!isHome}
+              to="/meetingRooms"
+              style={{ pointerEvents: 'none', opacity: 0.5 }}
+            >
               교내회의실 찾기
             </StyledLink>
             <SearchContainer>


### PR DESCRIPTION
2차 스프린트(?) 반영했습니다

- 헤더의 교내회의실 찾기 링크 비활성화, 클릭 안되게 함

<img width="391" alt="스크린샷 2025-06-11 오후 9 01 01" src="https://github.com/user-attachments/assets/4cfe4a3e-549a-4b1d-9004-da331501e66d" />
<img width="675" alt="스크린샷 2025-06-11 오후 9 02 40" src="https://github.com/user-attachments/assets/f0899c8c-a5c3-41e6-9521-f936d2dae91e" />
<img width="996" alt="스크린샷 2025-06-11 오후 9 00 55" src="https://github.com/user-attachments/assets/47967281-de91-4f44-b1be-c32a8c9a728a" />

- 그 main에 푸시해버렸는데 여기 이제 공간이름 대신 예약자 성함이 나오게 수정했아요
<img width="872" alt="스크린샷 2025-06-11 오후 9 10 47" src="https://github.com/user-attachments/assets/70be8e16-9947-4666-8588-3ebe8d75a1c9" />


궁금한 점 : 제롬 Mixpanel 제가 붙여도 되나여??